### PR TITLE
Replace global typing by exported types

### DIFF
--- a/src/utils/deferred.ts
+++ b/src/utils/deferred.ts
@@ -1,3 +1,5 @@
+import { TDeferred } from 'wowza-types';
+
 export function deferred<T>(): TDeferred<T> {
   const output = {} as TDeferred<T>;
 

--- a/src/webrtc-wowza-player.ts
+++ b/src/webrtc-wowza-player.ts
@@ -1,4 +1,12 @@
 import { EventEmitter } from 'events';
+
+import {
+  TPlayerOptions,
+  TVideoConfigs,
+  TAudioConfigs,
+  TStreamItem,
+} from 'wowza-types';
+
 import { getUserMedia } from './webrtc/getUserMedia';
 import { PeerConnection } from './webrtc/PeerConnection';
 import { Wowza } from './wowza/wowza';

--- a/src/webrtc/SDPEnhancer.ts
+++ b/src/webrtc/SDPEnhancer.ts
@@ -1,3 +1,5 @@
+import { TVideoConfigs, TAudioConfigs } from 'wowza-types';
+
 // Code adapted from https://github.com/WowzaMediaSystems/webrtc-examples/blob/master/src/lib/WowzaMungeSDP.js
 import { browser } from '../utils/browser';
 
@@ -35,7 +37,7 @@ export class SDPEnhancer {
     const sdp =
       lines
         .filter(Boolean)
-        .map(line => {
+        .map((line) => {
           const [header] = line.split(/\s|:/, 1);
 
           switch (header) {
@@ -157,7 +159,7 @@ export class SDPEnhancer {
     return profile !== 'VP8' && profile !== 'VP9'
       ? lines
       : lines.filter(
-          transport =>
+          (transport) =>
             !transport.includes('transport-cc') &&
             !transport.includes('goog-remb') &&
             !transport.includes('nack')
@@ -193,7 +195,7 @@ export class SDPEnhancer {
       tmp
     );
 
-    return lines.map(line => {
+    return lines.map((line) => {
       if (rtcpSize) {
         if (!done && line === 'a=rtcp-rsize') {
           done = true;
@@ -219,7 +221,7 @@ export class SDPEnhancer {
     const sdp = description.sdp || '';
 
     let lines = sdp.split(/\r\n/);
-    lines = lines.filter(line => line && this.checkLine(line, tmp));
+    lines = lines.filter((line) => line && this.checkLine(line, tmp));
     lines = this.flattenLines(this.addAudio(lines, tmp));
     lines = this.flattenLines(this.addVideo(lines, tmp));
 

--- a/src/wowza/wowza.ts
+++ b/src/wowza/wowza.ts
@@ -1,3 +1,11 @@
+import {
+  TStreamInfo,
+  TPlayerOptions,
+  TSocketRecvData,
+  TSocketSendData,
+  ValueOf,
+} from 'wowza-types';
+
 import { deferred } from '../utils/deferred';
 
 export class Wowza {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "*": ["node_modules/*", "src/*"]
+      "*": ["node_modules/*", "src/*", "typings/*"]
     },
     "lib": ["dom"]
   },

--- a/typings/wowza-types.ts
+++ b/typings/wowza-types.ts
@@ -1,7 +1,7 @@
-declare type ValueOf<T> = T[keyof T];
-declare type PartialObject<T> = { [P in keyof T]?: T[P] };
+export type ValueOf<T> = T[keyof T];
+export type PartialObject<T> = { [P in keyof T]?: T[P] };
 
-declare interface TPlayerOptions {
+export interface TPlayerOptions {
   sdpUrl?: string;
   applicationName?: string;
   streamName?: string;
@@ -18,24 +18,24 @@ declare interface TPlayerOptions {
   ) => RTCSessionDescriptionInit;
 }
 
-declare interface TVideoConfigs {
+export interface TVideoConfigs {
   bitRate: number;
   codec: '42e01f' | 'VP8' | 'VP9';
   frameRate: number;
 }
 
-declare interface TAudioConfigs {
+export interface TAudioConfigs {
   bitRate: number;
   codec: 'opus';
 }
 
-declare interface TStreamInfo {
+export interface TStreamInfo {
   applicationName: string;
   sessionId: string;
   streamName: string;
 }
 
-declare interface TStreamItem {
+export interface TStreamItem {
   streamName: string;
   readyAudio: boolean;
   readyVideo: boolean;
@@ -43,27 +43,27 @@ declare interface TStreamItem {
   codecVideo: number;
 }
 
-declare interface TDeferred<T> {
+export interface TDeferred<T> {
   resolve: (data: T) => void;
   promise: Promise<T>;
   reject: (data: T & { status: number; statusDescription: string }) => void;
 }
 
-declare interface TSocketSendBase {
+interface TSocketSendBase {
   direction: 'publish' | 'play';
   command: keyof TSocketSendData;
   streamInfo: TStreamInfo;
   userData: null;
 }
 
-declare interface TSocketRecvBase {
+interface TSocketRecvBase {
   direction: 'publish' | 'play';
   command: keyof TSocketRecvData;
   status: number;
   statusDescription: string;
 }
 
-declare interface TSocketSendData {
+export interface TSocketSendData {
   sendOffer: {
     direction: 'publish';
     command: 'sendOffer';
@@ -84,7 +84,7 @@ declare interface TSocketSendData {
   };
 }
 
-declare interface TSocketRecvData {
+export interface TSocketRecvData {
   sendOffer: TSocketRecvBase & {
     direction: 'publish';
     command: 'sendOffer';


### PR DESCRIPTION
This fixes issues with the packages, when tsc was used externally, global.d.ts was never computed