### PR TITLE
✨  Features to update the publish stream

### DIFF
--- a/src/webrtc-wowza-player.ts
+++ b/src/webrtc-wowza-player.ts
@@ -242,6 +242,10 @@ export class WowzaWebRTCPlayer extends EventEmitter {
       this.video.src = window.URL.createObjectURL(stream);
     }
 
+    if (this.pc) {
+      this.pc.attachMediaStream(stream);
+    }
+
     this.video.play();
   }
 }

--- a/src/webrtc/PeerConnection.ts
+++ b/src/webrtc/PeerConnection.ts
@@ -72,14 +72,22 @@ export class PeerConnection extends EventEmitter {
   }
 
   public attachMediaStream(mediaStream: MediaStream): void {
-    if (mediaStream.getTracks) {
-      mediaStream.getTracks().forEach((track) => {
-        this.pc.addTrack(track, mediaStream);
+    const pc = this.pc;
+    const senders = pc.getSenders();
+    const tracks = mediaStream.getTracks();
+
+    if (!senders.length) {
+      tracks.forEach((track) => {
+        pc.addTrack(track, mediaStream);
       });
-    } else if ('addStream' in this.pc) {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      // @ts-ignore
-      this.pc.addStream(mediaStream);
+    } else {
+      tracks.forEach((track) => {
+        senders
+          .filter((sender) => sender.track?.kind === track.kind)
+          .forEach((sender) => {
+            sender.replaceTrack(track);
+          });
+      });
     }
   }
 


### PR DESCRIPTION
By calling `player.attachStream(stream)` only the local video flux is updated, not the flux we are sending to wowza. This fixes the problem.