### PR TITLE
Fixed Regex to handle profile-level at the end of a line

### DIFF
--- a/src/webrtc/SDPEnhancer.ts
+++ b/src/webrtc/SDPEnhancer.ts
@@ -34,7 +34,7 @@ export class SDPEnhancer {
     //   ZZ: level ID
     // Look for codecs higher than baseline and force downward.
     description.sdp = description.sdp.replace(
-      /profile-level-id=(\w+);/gi,
+      /profile-level-id=(\w+)/gi,
       (_, $0) => {
         const profileId = parseInt($0, 16);
         let profile = (profileId >> 16) & 0xff;
@@ -48,11 +48,9 @@ export class SDPEnhancer {
         } else if (constraint === 0x00) {
           constraint = 0xe0;
         }
-
-        return ((profile << 16) | (constraint << 8) | level).toString(16);
+        return `profile-level-id=${((profile << 16) | (constraint << 8) | level).toString(16)}`;
       }
     );
-
     return description;
   }
 


### PR DESCRIPTION
The regular expression used in the processing of the SDP file seems to work, when the _profile-level-id_ is not the last argument in the list supplied to _a=fmtp_ as shown below:
```
....
a=fmtp:97 packetization-mode=1;profile-level-id=42e01f;sprop-parameter-sets=Z2QAH6yyAIAMNgLUBAQFAAADAAEAAAMAFI8YMkg=,aOvMsiw=
...
```
However, when the _profile-level-id_ is last in the list as shown below, the regex won't fire and the profile level will not be set.
```
....
a=fmtp:97 packetization-mode=1;sprop-parameter-sets=Z2QAH6yyAIAMNgLUBAQFAAADAAEAAAMAFI8YMkg=,aOvMsiw=;profile-level-id=42e01f
...
```
This can lead to streams not showing up correctly in some browsers.