### PR TITLE
Fix missing "on" and "emit" methods

### DIFF
--- a/src/webrtc/PeerConnection.ts
+++ b/src/webrtc/PeerConnection.ts
@@ -97,4 +97,12 @@ export class PeerConnection extends EventEmitter {
       this.emit('addstream', stream);
     });
   }
+  
+  on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  emit(event: string | symbol, ...args: any[]): boolean {
+    return super.emit(event, args);
+  }
 }


### PR DESCRIPTION
Add methods on, and emit from super class EventEmmiter. 

When EventEmmiter type is not found by NPM, typescript reports an error, saying that no methos on and emit was found in PeerConneciton class. 

This issue happens when user tries to use the library with @types/node version 12 or lower. Updating @types/nodes to 13 will also solve this typescript error. 

This is a workaround to the PeerConnection missing methods error.